### PR TITLE
Add commitizen for consistent commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Git Web Launcher [![CircleCI](https://circleci.com/gh/cnishina/github-web-launcher.svg?style=svg)](https://circleci.com/gh/cnishina/github-web-launcher)
+# Git Web Launcher 
+[![CircleCI](https://circleci.com/gh/cnishina/github-web-launcher.svg?style=shield)](https://circleci.com/gh/cnishina/github-web-launcher)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 Launching :rocket::rocket::rocket: from command line to GitHub :octocat: for Chrome
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "prepublish": "tsc",
+    "commit": "git-cz",
     "tsc": "tsc",
     "test-int": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-int.json",
     "test-unit": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-unit.json"
@@ -33,7 +34,14 @@
     "@types/node": "^10.5.2",
     "@types/parse-git-config": "^2.0.0",
     "@types/selenium-webdriver": "^3.0.10",
+    "commitizen": "^2.10.1",
+    "cz-conventional-changelog": "^2.1.0",
     "jasmine": "^3.1.0",
     "typescript": "^2.9.2"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This allows contributors to follow consistent commit messages while contributing!

* Stage the changes to the files and run `npm run commit`
* Commitizen will guide the next set of actions :)